### PR TITLE
UDP streamer ignores socket write errors

### DIFF
--- a/ignorant-writer.go
+++ b/ignorant-writer.go
@@ -1,0 +1,12 @@
+package main
+
+import "io"
+
+type IgnorantWriter struct {
+	original io.Writer
+}
+
+func (w IgnorantWriter) Write(p []byte) (int, error) {
+	n, _ := w.original.Write(p)
+	return n, nil
+}

--- a/logspout.go
+++ b/logspout.go
@@ -76,7 +76,7 @@ func udpStreamer(target Target, types []string, logstream chan *Log) {
 	assert(err, "resolve udp failed")
 	conn, err := net.DialUDP("udp", nil, addr)
 	assert(err, "connect udp failed")
-	encoder := json.NewEncoder(conn)
+	encoder := json.NewEncoder(&IgnorantWriter{conn})
 	defer conn.Close()
 	for logline := range logstream {
 		if typestr != ",," && !strings.Contains(typestr, logline.Type) {


### PR DESCRIPTION
The problem: Golang's json encoder stops encoding after a first `Write()` error. http://golang.org/src/encoding/json/stream.go?s=3688:3735#L156

In logspout case, this means that if a remote does not listen on the specified port, the stream will keep working, but will output nothing. The behavior of silently ignoring an error is basically bad. As a user I expect 2 possible scenarios:
 1. ignore the errors: ignore socket write errors, and keep sending UDP datagrams anyway.
 2. terminate the stream on error.

IMHO, the last scenario does not make much sense in case of UDP. If no one is listening on the other side, then just remove the route. But while the route is present, try to deliver the logs. So I've implemented the first one.